### PR TITLE
お問い合わせフォームのリンクをGoogleフォームからaiformに変更

### DIFF
--- a/contact/templates/contact/top.html
+++ b/contact/templates/contact/top.html
@@ -9,7 +9,7 @@
       </div>
     </div>
   </div>
-  <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfMEDG3ZWGPx6p2O_uOaE9ZlcqXSV9d57wc2-5kCgxlh_k-oQ/viewform?embedded=true" width="640" height="876" frameborder="0" marginheight="0" marginwidth="0">読み込んでいます…</iframe>
+  <a href="https://aiform.nisyuu.com/view/lLykEN4pSxrBiUHXTghu" target="_blank" rel="noopener noreferrer" class="inline-block bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-4 rounded">お問い合わせフォームを開く</a>
 </div>
 <script type="text/javascript">
 {% for message in messages %}


### PR DESCRIPTION
## Summary\n- `contact/templates/contact/top.html` のGoogleフォーム埋め込み `<iframe>` を削除\n- 新しいお問い合わせフォーム（https://aiform.nisyuu.com/view/lLykEN4pSxrBiUHXTghu）へのリンクボタンに変更\n\nhttps://claude.ai/code/session_01YaBEZwDhd4SoBKKi88QsDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaBEZwDhd4SoBKKi88QsDx)_